### PR TITLE
BC2A-1408: Fix hardcoded path for dynamically generated c file

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -68,7 +68,7 @@ jobs:
     
     steps:
       - name: Install dependencies
-        run: apt update && apt install -qy openjdk-11-jdk-headless git
+        run: apt update && apt install -qy openjdk-17-jdk-headless git
 
       - name: Download app binary
         uses: actions/download-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -138,16 +138,13 @@ else
     DEFINES += PRINTF\(...\)=
 endif
 
-AUTOGEN_SRC := src/txnTypeLists.c
-AUTOGEN_OBJ := $(AUTOGEN_SRC:src/%.c=obj/%.o)
+AUTOGEN_SRC := $(PWD)/src/txnTypeLists.c
 
 SOURCE_FILES += $(AUTOGEN_SRC)
 
 .PHONY: realclean clean
 
 all: default
-
-$(AUTOGEN_OBJ): src/authAndSignTxn.c $(AUTOGEN_SRC)
 
 $(AUTOGEN_SRC): createTxnTypes.py txtypes.txt
 	python ./createTxnTypes.py > $@


### PR DESCRIPTION
The Makefile dynamically creates a c file, and its corresponding obj was hardcoded.

There is no need to declare the `obj` file, that will be dynamically computed by the SDK.

In addition fix the test workflow, replacing a package version.